### PR TITLE
Added glib2-devel installation requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ WhiteSur is a MacOS Big Sur like theme for GTK 3, GTK 2 and Gnome-Shell which su
 
 ### GTK+ 3.20 or later
 
-### GTK2 engines requirment
+### GTK2 engines requirements
 - GTK2 engine Murrine 0.98.1.1 or later.
 - GTK2 pixbuf engine or the gtk(2)-engines package.
 
@@ -24,17 +24,18 @@ ArchLinux:
     pacman -S gtk-engine-murrine gtk-engines
 
 
-### Installation Depends requirment
+### Installation Depends requirement
 - sassc.
 - optipng.
 - inkscape.
 - libglib2.0-dev. `ubuntu 18.04` `debian 10.03` `linux mint 19`
 - libxml2-utils. `ubuntu 18.04` `debian 10.03` `linux mint 19`
+- glib2-devel. `Fedora` `Redhat`
 
 Fedora/RedHat distros:
 
-    dnf install sassc optipng inkscape
-
+    dnf install sassc optipng inkscape glib2-devel
+    
 Ubuntu/Mint/Debian distros:
 
     sudo apt install sassc optipng inkscape
@@ -48,13 +49,14 @@ ArchLinux:
     pacman -S sassc optipng inkscape
 
 Other:
-Search for the depends in your distributions repository or install the depends from source.
+1. Search for the dependencies in your distribution's repository or install the dependencies from source.
+2. For CentOS 8 users: the `sassc` package doesn't exist in EPEL 8 or any other main repositories. Download the RPM manually from older EPEL repositories or build from source.
 
 ## Installation
 
 ### From source
 
-After depends all installed you can Run
+After all the dependencies are installed, you can Run
 
     ./install.sh
 


### PR DESCRIPTION
Installing the theme in Fedora/Redhat/CentOS requires the package **glib2-devel** which is not installed in these operating systems by default.
I added this to the dependencies installation requirement.

Apart from that, the main dependency `sassc` doesn't exist in the EPEL 8 version repository and CentOS 8 users have no other way to install this package from any repository (one cannot change the version of EPEL to go back to the older versions and install `sassc` from there). I added this note to the README file.

I've also corrected a few typos.

Thank You! :D