### PR TITLE
Added compromize fix for NVIDIA

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -199,6 +199,8 @@ install() {
   cp -r ${SRC_DIR}/other/plank/theme${color}/*.theme                                    ${THEME_DIR}/plank
 }
 
+nautilus_use_colors='false'
+
 while [[ $# -gt 0 ]]; do
   case "${1}" in
     -d|--dest)
@@ -497,6 +499,10 @@ while [[ $# -gt 0 ]]; do
       usage
       exit 0
       ;;
+    --nautilus-use-colors)
+      nautilus_use_colors='true'
+      break
+      ;;
     *)
       prompt -e "ERROR: Unrecognized installation option '$1'."
       prompt -i "Try '$0 --help' for more information."
@@ -556,6 +562,11 @@ customize_theme() {
   # Change nautilus sibarbar size
   if [[ "${size:-}" == 'true' && "${sidebar_size:-}" != 'default' ]]; then
     change_size
+  fi
+
+  # Force nautilus to use colors instead of images
+  if [[ "${nautilus_use_colors}" == 'true' ]]; then
+    force_nautilus_use_colors
   fi
 }
 
@@ -795,6 +806,12 @@ change_transparency() {
     sed -i.bak "/\$panel_opacity/s/0.16/0.${panel_opacity}/" _variables.scss
     prompt -w "Change panel transparency ..."
   fi
+}
+
+force_nautilus_use_colors() {
+  cd ${SRC_DIR}/sass
+  sed -i.bak "/\$nautilus_use_colors/s/false/true/" _variables.scss
+  prompt -w "Forcing nautilus to use colors instead of images ..."
 }
 
 restore_files() {

--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -75,3 +75,6 @@ $shadow_6: 0 0 8px rgba(black, 0.2), 0 0 4px rgba(black, 0.3);              // S
 $text_shadow: 0 -1px rgba(white, 0.04), -1px 0 rgba(black, 0.05),
               1px 0 rgba(black, 0.05), 0 1px rgba(black, 0.3),
               0 2px rgba(black, 0.05);                                      // text and icon shadow
+
+// Force nautilus styles to exclusively use colors instead of linear-gradients
+$nautilus_use_colors: false;

--- a/src/sass/gtk/_applications.scss
+++ b/src/sass/gtk/_applications.scss
@@ -87,8 +87,12 @@ filechooser,
 .nautilus-window {
   paned > separator { // Use paned separator to hide stack border-bottom-left-radius
     border: none;
-    background-color: transparent;
-    background-image: image($base_color);
+    @if $nautilus_use_colors {
+      background-color: rgba($bg_color, 0.95);
+    } @else {
+      background-color: transparent;
+      background-image: image($base_color);
+    }
     background-size: $wm_radius $wm_radius;
     background-position: left bottom;
     background-repeat: no-repeat;
@@ -107,14 +111,22 @@ filechooser,
 .nautilus-window {
   &.background.csd {
     border-radius: 0 0 $wm_radius $wm_radius;
-    background-color: transparent;
-    background-image: $nautilus_background_image;
+    @if $nautilus_use_colors {
+      background-color: rgba($bg_color, 0.95);
+    } @else {
+      background-color: transparent;
+      background-image: $nautilus_background_image;
+    }
 
     > headerbar.titlebar {
       border: none;
       box-shadow: inset 0 1px rgba(white, 0.1);
       background: none;
-      background-image: $nautilus_header_image;
+      @if $nautilus_use_colors {
+        background-color: $base_color;
+      } @else {
+        background-image: $nautilus_header_image;
+      }
 
       > .linked.raised > button:first-child { margin-left: $nautilus_sidebar_size - 80px; }
 


### PR DESCRIPTION
This pull request provides a compromise between full solid theme and transparent theme and still renders properly under the combination of NVIDIA + GNOME compositor.

This pull request is not destructive, it just simply adds a new options which forces the use of colors instead of images to prevent rendering bugs. By default the theme is unchanged.