### PR TITLE
Fix typo in README

### DIFF
--- a/src/other/dash-to-dock/README.md
+++ b/src/other/dash-to-dock/README.md
@@ -4,7 +4,7 @@
 
 ### Install tips
 
-Usage:  `./Install`  **[OPTIONS...]**
+Usage:  `./install.sh`  **[OPTIONS...]**
 
 |  OPTIONS:           | |
 |:--------------------|:-------------|


### PR DESCRIPTION
Hi, 

When trying to install dash to dock, I realised that you could not use "./Install". To install dash to dock you must use "./install.sh". 

So I fixed it. 

Regards,
T0mR20