### PR TITLE
Add 'rounded window even when it gets maximized' feature

### DIFF
--- a/src/other/firefox/chrome/WhiteSur/parts/csd.css
+++ b/src/other/firefox/chrome/WhiteSur/parts/csd.css
@@ -7,7 +7,7 @@
 }
 
 /* Headerbar top border corners rounded */
-:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
+:root[tabsintitlebar]:not([inFullscreen]):not([sizemode="maximized"]) #nav-bar {
 	border-radius: 16px 16px 0 0 !important;
 }
 

--- a/src/other/firefox/chrome/WhiteSur/rounded-window-maximized.css
+++ b/src/other/firefox/chrome/WhiteSur/rounded-window-maximized.css
@@ -1,0 +1,5 @@
+@namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+
+:root[tabsintitlebar]:not([inFullscreen]) #nav-bar {
+	border-radius: 16px 16px 0 0;
+}

--- a/src/other/firefox/chrome/customChrome.css
+++ b/src/other/firefox/chrome/customChrome.css
@@ -1,0 +1,3 @@
+
+/* Add your own custom styles here */
+

--- a/src/other/firefox/chrome/userChrome.css
+++ b/src/other/firefox/chrome/userChrome.css
@@ -21,6 +21,9 @@
 /* Rounded title buttons (headerbar window controls) (GNOMISH) */
 /*@import "WhiteSur/rounded-title-buttons.css"; /**/
 
+/* Rounded window even when it gets maximized */
+/*@import "WhiteSur/rounded-window-maximized.css"; /**/
+
 /* Active tab high contrast */
 /*@import "WhiteSur/active-tab-contrast.css"; /**/
 


### PR DESCRIPTION
Hi Vince! I really appreciate your work :+1: , but honestly, I don't like the new change about the rounded headerbar here in Firefox CSS. I know it looks more like the real BigSur Safari, but umm... So yeah, I made a new option/feature to enable or disable it. Is that okay? :) :gift: 