### PR TITLE
Use different approach for distro detection and do a code refactoring

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -126,7 +126,7 @@ else
 
   echo; install_themes; echo; prompt -s "Done!"
 
-  if [[ "${DISTRO_BASE}" == "arch" && "$(which xfce4-session 2> /dev/null)" ]]; then
+  if is_my_distro "arch" && has_command xfce4-session; then
     msg="XFCE: you may need to logout after changing your theme to fix your panel opacity."
     notif_msg="${msg}\n\n${final_msg}"
 

--- a/lib-core.sh
+++ b/lib-core.sh
@@ -18,7 +18,6 @@ else LIB_CORE_IMPORTED="true"; fi
 
 export WHITESUR_PID=$$
 MY_USERNAME="$(logname 2> /dev/null || echo ${SUDO_USER:-${USER}})"
-DISTRO_BASE="$(cat '/etc/os-release' | awk -F '=' '/ID_LIKE/{print $2}')"
 
 if command -v gnome-shell &> /dev/null; then
   if (( $(gnome-shell --version | cut -d ' ' -f 3 | cut -d . -f 1) >= 4 )); then
@@ -202,6 +201,10 @@ helpify() {
 # Check command availability
 has_command() {
   command -v "$1" &> /dev/null
+}
+
+is_my_distro() {
+  [[ "$(cat '/etc/os-release' | awk -F '=' '/ID/{print $2}')" =~ "${1}" ]]
 }
 
 ###############################################################################
@@ -454,7 +457,7 @@ backup_file() {
 }
 
 check_theme_file() {
-  [[ -f "${1}" || -f "${1}.bak" ]] && return 0 || return 1
+  [[ -f "${1}" || -f "${1}.bak" ]]
 }
 
 remind_relative_path() {

--- a/lib-install.sh
+++ b/lib-install.sh
@@ -23,8 +23,8 @@ source "${REPO_DIR}/lib-core.sh"
 ###############################################################################
 
 install_theme_deps() {
-  if [[ ! "$(which glib-compile-resources 2> /dev/null)" || ! "$(which sassc 2> /dev/null)" || \
-    ! -r "/usr/share/gtk-engines/murrine.xml" || ! "$(which xmllint 2> /dev/null)" ]]; then
+  if ! has_command glib-compile-resources || ! has_command sassc || \
+    ! has_command xmllint || [[ ! -r "/usr/share/gtk-engines/murrine.xml" ]]; then
     echo; prompt -w "'glib2.0', 'sassc', 'xmllint', 'libmurrine' are required for theme installation."
 
     if has_command zypper; then
@@ -47,7 +47,7 @@ install_theme_deps() {
 }
 
 install_beggy_deps() {
-  if [[ ! "$(which convert 2> /dev/null)" ]]; then
+  if ! has_command convert; then
     echo; prompt -w "'imagemagick' are required for this option."
 
     if has_command zypper; then
@@ -67,7 +67,7 @@ install_beggy_deps() {
 }
 
 install_dialog_deps() {
-  if [[ ! "$(which dialog 2> /dev/null)" ]]; then
+  if ! has_command dialog; then
     echo; prompt -w "'dialog' are required for this option."
 
     if has_command zypper; then
@@ -297,9 +297,12 @@ install_theemy() {
 
 remove_packy() {
   rm -rf "${dest}/${name}$(destify ${1})$(destify ${2})$(destify ${3})$(destify ${4})"
-  rm -rf "${dest}/${name}$(destify ${1})-mdpi"
+  rm -rf "${dest}/${name}$(destify ${1})"
   rm -rf "${dest}/${name}$(destify ${1})-hdpi"
   rm -rf "${dest}/${name}$(destify ${1})-xhdpi"
+
+  # Backward compatibility
+  rm -rf "${dest}/${name}$(destify ${1})-mdpi"
 }
 
 ###############################################################################

--- a/src/assets/render-all-assets.sh
+++ b/src/assets/render-all-assets.sh
@@ -8,7 +8,7 @@ has_command() {
   "$1" -v $1 > /dev/null 2>&1
 }
 
-if [ ! "$(which inkscape 2> /dev/null)" ]; then
+if ! has_command inkscape; then
   echo inkscape and optipng needs to be installed to generate the assets.
   if has_command zypper; then
     sudo zypper in inkscape optipng

--- a/tweaks.sh
+++ b/tweaks.sh
@@ -67,7 +67,7 @@ while [[ $# -gt 0 ]]; do
           edit_firefox="true" ;;
       esac
 
-      if [[ ! "$(which firefox 2> /dev/null)" ]]; then
+      if ! has_command firefox; then
         prompt -e "'${1}' ERROR: There's no Firefox installed in your system"
         has_any_error="true"
       elif [[ ! -d "${FIREFOX_DIR_HOME}" ]]; then
@@ -81,21 +81,21 @@ while [[ $# -gt 0 ]]; do
     -F|--flatpak)
       flatpak="true";
 
-      if [[ ! "$(which flatpak 2> /dev/null)" ]]; then
+      if ! has_command flatpak; then
         prompt -e "'${1}' ERROR: There's no Flatpak installed in your system"
         has_any_error="true"
       fi; shift ;;
     -s|--snap)
       snap="true";
 
-      if [[ ! "$(which snap 2> /dev/null)" ]]; then
+      if ! has_command snap; then
         prompt -e "'${1}' ERROR: There's no Snap installed in your system"
         has_any_error="true"
       fi; shift ;;
     -g|--gdm)
       gdm="true"; full_rootify "${1}"
 
-      if [[ ! "$(which gdm 2> /dev/null)" && ! "$(which gdm3 2> /dev/null)" ]]; then
+      if ! has_command gdm && ! has_command gdm3; then
         prompt -e "'${1}' ERROR: There's no GDM installed in your system"
         has_any_error="true"
       fi; shift ;;


### PR DESCRIPTION
I found a great collection of `os_release` [here!](https://github.com/chef/os_release#why-collect-them)

In that repo, they said

> Why collect them
> 
> The fields in /etc/os-release are standardized, but the values are not. The only way to know that Redhat Enterprise Linux is 'rhel' or that openSUSE 15 is 'opensuse-leap' is to install the distros and check the file. This repo is a large collection of os-release files so you don't need to install each and every distro.

That's why I use a different approach for distro detection that read "ID" variables like `ID` and `ID_LIKE` and find a distro name there. BTW, some distros have multiple ID_LIKE-s, for example `"rhel fedora"`. So I think this approach is gonna work great for most cases