### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ Parameter: `--flatpak` `-F`
 Example: `./tweaks.sh -F`
 
 ### <p align="center"> <b> Connect WhiteSur theme to your Snap apps </b> </p>
-Parameter: `--snap` `-S`
+Parameter: `--snap` `-s`
 
-Example: `./tweaks.sh -S`
+Example: `./tweaks.sh -s`
 
 Note:
 


### PR DESCRIPTION
The command-line switch for using the theme for Snap apps is a lowercase s, not uppercase.
I'm not sure if that's supposed to be implemented as -S or if it's just a typo, but I thought I'd correct in the meantime just to avoid confusion for users.