### PR TITLE
Move close icon to the left

### DIFF
--- a/src/other/firefox/WhiteSur/parts/tabsbar.css
+++ b/src/other/firefox/WhiteSur/parts/tabsbar.css
@@ -96,6 +96,7 @@ tab[selected]:-moz-window-inactive {
 /* Center all inside tab */
 .tab-content {
 	display: flex;
+	flex-direction: row;
 	justify-content: center;
 	align-items: center;
 	margin-top: -1px;
@@ -118,11 +119,32 @@ tab[selected]:-moz-window-inactive {
 .tab-icon-sound[activemedia-blocked="true"] {
 	margin-left: auto !important;
 }
-.tabbrowser-tab:not([soundplaying]):not([muted]):not([activemedia-blocked]) .tab-close-button {
-	margin-left: auto !important;
-}
+
 .tab-icon-sound {
 	margin-right: 6px;
+}
+.tabbrowser-tab > .tab-stack > .tab-content > .tab-close-button {
+	order: 1;
+}
+.tabbrowser-tab > .tab-stack > .tab-content > .tab-icon-stack {
+	order: 2;
+	margin-left: auto;
+}
+.tabbrowser-tab > .tab-stack > .tab-content > .tab-label-container {
+	order: 3;
+	margin-right: auto;
+}
+
+.tabbrowser-tab > .tab-stack > .tab-content > .tab-close-button {
+	visibility: hidden;
+}
+
+.tabbrowser-tab:hover > .tab-stack > .tab-content > .tab-close-button {
+	visibility: visible;
+}
+
+.tabbrowser-tab > .tab-stack > .tab-content > .tab-label-container > .tab-secondary-label {
+	display: none;
 }
 
 /* Force tab favicon to the center */


### PR DESCRIPTION
Left align the close icon, hide it unless hovered and hide the "PLAYING" label to fit closer to the style of Safari.

Fix https://github.com/vinceliuice/WhiteSur-gtk-theme/issues/399

Hover:
![image](https://user-images.githubusercontent.com/1382565/131745454-40730599-67d6-42a3-909c-32508e75769a.png)

Default:
![image](https://user-images.githubusercontent.com/1382565/131745505-b97e0e94-3305-4772-9b1a-2bbd062a4126.png)

## Note
I have only tested this on Firefox available on Arch Linux, it will require testing on ~~macOS and~~ Windows 