### PR TITLE
Fix length of ICON_VARIANTS check.

### DIFF
--- a/lib-core.sh
+++ b/lib-core.sh
@@ -558,7 +558,7 @@ check_param() {
           fi
         done ;;
       -i)
-        for i in {0..12}; do
+        for i in {0..13}; do
           if [[ "${value}" == "${ICON_VARIANTS[i]}" ]]; then
             icon="${ICON_VARIANTS[i]}"; variant_found="true"; break
           fi


### PR DESCRIPTION
ICON_VARIANTS has 14 entries but is currently only checked up to the 13th.
Fixes an error when `-i zorin` is specified.