### PR TITLE
Update _common-3.0.scss

### DIFF
--- a/src/sass/gtk/_common-3.0.scss
+++ b/src/sass/gtk/_common-3.0.scss
@@ -4242,6 +4242,11 @@ decoration {
     &.maximized, &.tiled { border-radius: 0; }
   }
 
+  .metacity & {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
   .csd.popup & {
     border-radius: $mn_radius;
     box-shadow: 0 5px 8px rgba(0, 0, 0, 0.15), 0 8px 15px rgba(0, 0, 0, 0.08), $wm_outline;


### PR DESCRIPTION
<!------------------------------------------------------------------------------
What's the changes?
------------------------------------------------------------------------------->

`metacity` added a new `style_info` to allow `metacity` customization. This PR prevents bottom rounded corners on window manager `metacity`
See: https://github.com/GNOME/metacity/commit/722d086d756b8ecf0c463b07cb378c872615937f
