### PR TITLE
Update headerbar-urlbar.css

### DIFF
--- a/src/other/firefox/Monterey/parts/headerbar-urlbar.css
+++ b/src/other/firefox/Monterey/parts/headerbar-urlbar.css
@@ -30,7 +30,7 @@ toolbarspring {
 	border-radius: 8px !important;
 	border: 1px solid transparent !important;
 	padding: 0 0 !important;
-	max-width: 360px !important;
+	max-width: 320px !important;
 }
 #urlbar-background {
 	box-shadow: none !important;
@@ -49,21 +49,21 @@ toolbarspring {
 #wrapper-urlbar-container,
 #urlbar #urlbar-input-container {
 	padding: 0 !important;
-	width: 360px !important;
-	min-width: 360px !important;
+	width: 320px !important;
+	min-width: 320px !important;
 }
 
 :root[sizemode="maximized"] #urlbar,
 :root[sizemode="maximized"] #urlbar-container,
 :root[sizemode="maximized"] #wrapper-urlbar-container {
-	width: 360px !important;
-	min-width: 360px !important;
+	width: 320px !important;
+	min-width: 320px !important;
 }
 
 #urlbar[breakout][breakout-extend] {
 	left: 0 !important;
 	top: 0 !important;
-	width: 360px !important;
+	width: 320px !important;
 	z-index: 5 !important;
 	padding: 0 0 !important;
 }


### PR DESCRIPTION
Made the tabs and url bar be seperated. This tweak edits the width of the urlbar so that the tabs are not attached to the url bar. I think this is how it is in macos monterey's safari. PLEASE MAKE THIS THE DEFAULT. DO NOT PUT THIS AS A OPTIONAL TWEAK. 

<!------------------------------------------------------------------------------
What's the changes?
------------------------------------------------------------------------------->

-
-
-

