### PR TITLE
lib-install.sh: Disallow 'xfce4-panel -r' for the root user

### DIFF
--- a/shell/lib-install.sh
+++ b/shell/lib-install.sh
@@ -563,7 +563,7 @@ fix_whiskermenu() {
     sed -i "s|.*menu-opacity=.*|menu-opacity=95|" "$HOME/.config/xfce4/panel/whiskermenu"*".rc"
   fi
 
-  if (pgrep xfce4-session &> /dev/null); then
+  if pgrep xfce4-session &> /dev/null && [ "$(id -u)" -ne 0 ]; then
     xfce4-panel -r
   fi
 }


### PR DESCRIPTION
Packaging error on Arch Linux since commit [3bef54f].

Because packaging is carried out in [fakeroot], executing `xfce4-panel -r` in it can't get the expected results.
Packaging does not install the package, so there is no need to execute this command.

Normally, Xorg will not be run by ROOT user, so this modification will not affect other Linux distributions.

[3bef54f]: https://github.com/vinceliuice/WhiteSur-gtk-theme/commit/3bef54f42ec56017359c8c24ad80f4aa864a8743
[fakeroot]: https://man.archlinux.org/man/core/fakeroot/fakeroot.1.en