### PR TITLE
Firefox 121 - Opacity glitch with NVIDIA and Wayland env

### DIFF
--- a/src/other/firefox/common/parts/csd.css
+++ b/src/other/firefox/common/parts/csd.css
@@ -2,6 +2,10 @@
 
 @namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
+#main-window {
+	-moz-appearance: -moz-window-titlebar !important;
+}
+
 /* Headerbar top border corners rounded */
 :root[tabsintitlebar][sizemode="normal"]:not([gtktiledwindow="true"]) {
   #nav-bar {


### PR DESCRIPTION
See #1020 
When the firefox screen wasn't in focus, it had an invisible transparency that allowed you to see the programs and windows below (behind) it. With this little fix the glitch doesn't happen 
