### PR TITLE
Adapt font size if laptop or not

### DIFF
--- a/src/sass/_variables.scss
+++ b/src/sass/_variables.scss
@@ -21,7 +21,7 @@ $large-font-family: Roboto, "M+ 1c", Cantarell, Sans-Serif;
 // font sizes
 $root-font-size: if($laptop == 'false', 15px, 13px);
 $subheading-size: if($laptop == 'false', 17px, 15px);
-$base_font_size: 11pt;
+$base_font_size: if($laptop == 'false', 11pt, 10pt);
 
 // opacities
 $higher_opacity: 0.9;


### PR DESCRIPTION
Sets the base font size to 10pt if laptop mode is enabled, or 11pt if not in laptop mode.

Why even change it? It looks horrible on less-than-FHD monitors.
