### PR TITLE
cinnamon.scss: fix calendar applet scaled text bug

### DIFF
--- a/src/sass/cinnamon/_common.scss
+++ b/src/sass/cinnamon/_common.scss
@@ -756,7 +756,7 @@ StScrollBar {
 
 .calendar-day-base {
   text-align: center;
-  width: 28px;
+  min-width: 28px;
   height: 28px;
   padding: 0;
   margin: 2px;
@@ -825,7 +825,7 @@ StScrollBar {
 }
 
 .calendar-week-number {
-  width: 20px;
+  min-width: 20px;
   height: 20px;
   margin: 6px 0;
   color: transparentize($fg_color, 0.3);


### PR DESCRIPTION
Cinnamon calendar applet: remove width limit to allow for larger font sizes or cinnamon text scaling.

cf. https://github.com/vinceliuice/Orchis-theme/pull/446

