### PR TITLE
Edited tweaks.sh -h for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Usage:  `./tweaks.sh [OPTIONS...]`
 
  [Others]... options
 
-  -f, --firefox         [(monterey/flat)|alt|darker|adaptive]   Without options default WhiteSur theme will install...   Options:
+  -f, --firefox         [(monterey|flat)|alt|(darker|adaptive)]   Without options default WhiteSur theme will install...   Options:
 
       1. monterey       [3+3|3+4|3+5|4+3|4+4|4+5|5+3|5+4|5+5]   Topbar buttons number: 'a+b'   a: left side buttons number, b: right side buttons number
 
@@ -269,7 +269,7 @@ Usage:  `./tweaks.sh [OPTIONS...]`
 
       5. adaptive       Adaptive color version   You need install adaptive-tab-bar-colour plugin first   https://addons.mozilla.org/firefox/addon/adaptive-tab-bar-colour/
 
-  -e, --edit-firefox [(monterey/flat)|alt|darker|adaptive]
+  -e, --edit-firefox [(monterey|flat)|alt|(darker|adaptive)]
    Edit 'WhiteSur' theme for Firefox settings and also connect the theme to the current Firefox profiles. 
 
   -F, --flatpak Support options: [-o, -c, -t...]

--- a/tweaks.sh
+++ b/tweaks.sh
@@ -47,7 +47,7 @@ usage() {
   sec_title "-f, --firefox" "        [(monterey|flat)|alt|(darker|adaptive)]"       "  Without options default WhiteSur theme will install..."                      "  Options:"
   sec_helpify "1. monterey" "      [3+3|3+4|3+5|4+3|4+4|4+5|5+3|5+4|5+5]"           "  Topbar buttons number: 'a+b'"                                                "  a: left side buttons number, b: right side buttons number"
   sec_helpify "2. flat" "          Monterey alt version"                            ""                                                                              "  Flat round tabs..."
-  sec_helpify "3. alt" "           Alt windows button version"                      ""                                                                              "  Alt windows button version"
+  sec_helpify "3. alt" "           Alt windows button version"                      ""                                                                              "  Alt windows button style like gtk theme"
   sec_helpify "4. darker" "        Darker Firefox theme version"                    ""                                                                              "  Darker Firefox theme version"
   sec_helpify "5. adaptive" "      Adaptive color version"                          "  You need install adaptive-tab-bar-colour plugin first"                       "  https://addons.mozilla.org/firefox/addon/adaptive-tab-bar-colour/"
 

--- a/tweaks.sh
+++ b/tweaks.sh
@@ -44,13 +44,14 @@ usage() {
   helpify "--nord, --nordcolor" ""                                                  "  Install '${THEME_NAME}' Nord ColorScheme themes"                             ""
 
   helpify "" "" "[Others].." "options"
-  sec_title "-f, --firefox" "        [(monterey|flat) (darker|adaptive)]"         "  Without options default WhiteSur theme will install..."                      "  Options:"
+  sec_title "-f, --firefox" "        [(monterey|flat)|alt|(darker|adaptive)]"       "  Without options default WhiteSur theme will install..."                      "  Options:"
   sec_helpify "1. monterey" "      [3+3|3+4|3+5|4+3|4+4|4+5|5+3|5+4|5+5]"           "  Topbar buttons number: 'a+b'"                                                "  a: left side buttons number, b: right side buttons number"
   sec_helpify "2. flat" "          Monterey alt version"                            ""                                                                              "  Flat round tabs..."
-  sec_helpify "3. darker" "        Darker Firefox theme version"                    ""                                                                              "  Darker Firefox theme version"
-  sec_helpify "4. adaptive" "      Adaptive color version"                          "  You need install adaptive-tab-bar-colour plugin first"                       "  https://addons.mozilla.org/firefox/addon/adaptive-tab-bar-colour/"
+  sec_helpify "3. alt" "           Alt windows button version"                      ""                                                                              "  Alt windows button version"
+  sec_helpify "4. darker" "        Darker Firefox theme version"                    ""                                                                              "  Darker Firefox theme version"
+  sec_helpify "5. adaptive" "      Adaptive color version"                          "  You need install adaptive-tab-bar-colour plugin first"                       "  https://addons.mozilla.org/firefox/addon/adaptive-tab-bar-colour/"
 
-  helpify "-e, --edit-firefox"  "[(monterey|flat) (darker|adaptive)]"             "  Edit '${THEME_NAME}' theme for Firefox settings and also connect the theme to the current Firefox profiles" ""
+  helpify "-e, --edit-firefox"  "[(monterey|flat)|alt|(darker|adaptive)]"           "  Edit '${THEME_NAME}' theme for Firefox settings and also connect the theme to the current Firefox profiles" ""
 
   helpify "-F, --flatpak"       "Support options: [-o, -c, -t...]"                  "  Connect '${THEME_NAME}' theme to Flatpak"                                    "Without options will only install default themes"
 

--- a/tweaks.sh
+++ b/tweaks.sh
@@ -44,14 +44,13 @@ usage() {
   helpify "--nord, --nordcolor" ""                                                  "  Install '${THEME_NAME}' Nord ColorScheme themes"                             ""
 
   helpify "" "" "[Others].." "options"
-  sec_title "-f, --firefox" "        [(monterey/flat)|alt|darker|adaptive]"         "  Without options default WhiteSur theme will install..."                      "  Options:"
+  sec_title "-f, --firefox" "        [(monterey|flat) (darker|adaptive)]"         "  Without options default WhiteSur theme will install..."                      "  Options:"
   sec_helpify "1. monterey" "      [3+3|3+4|3+5|4+3|4+4|4+5|5+3|5+4|5+5]"           "  Topbar buttons number: 'a+b'"                                                "  a: left side buttons number, b: right side buttons number"
   sec_helpify "2. flat" "          Monterey alt version"                            ""                                                                              "  Flat round tabs..."
-  sec_helpify "3. alt" "           Alt windows button version"                      ""                                                                              "  Alt window button style like gtk theme"
-  sec_helpify "4. darker" "        Darker Firefox theme version"                    ""                                                                              "  Darker Firefox theme version"
-  sec_helpify "5. adaptive" "      Adaptive color version"                          "  You need install adaptive-tab-bar-colour plugin first"                       "  https://addons.mozilla.org/firefox/addon/adaptive-tab-bar-colour/"
+  sec_helpify "3. darker" "        Darker Firefox theme version"                    ""                                                                              "  Darker Firefox theme version"
+  sec_helpify "4. adaptive" "      Adaptive color version"                          "  You need install adaptive-tab-bar-colour plugin first"                       "  https://addons.mozilla.org/firefox/addon/adaptive-tab-bar-colour/"
 
-  helpify "-e, --edit-firefox"  "[(monterey/flat)|alt|darker|adaptive]"             "  Edit '${THEME_NAME}' theme for Firefox settings and also connect the theme to the current Firefox profiles" ""
+  helpify "-e, --edit-firefox"  "[(monterey|flat) (darker|adaptive)]"             "  Edit '${THEME_NAME}' theme for Firefox settings and also connect the theme to the current Firefox profiles" ""
 
   helpify "-F, --flatpak"       "Support options: [-o, -c, -t...]"                  "  Connect '${THEME_NAME}' theme to Flatpak"                                    "Without options will only install default themes"
 


### PR DESCRIPTION
- Removed "alt" option, which has been renamed "flat" (Fixed #1130) 
- Added an indication that "darker" and "adaptive" cannot be used together