### PR TITLE
Removal of forcing background-color for tabs

### DIFF
--- a/src/other/firefox/WhiteSur/parts/tabsbar.css
+++ b/src/other/firefox/WhiteSur/parts/tabsbar.css
@@ -79,7 +79,6 @@
 /* Tab labels */
 tab {
 	color: var(--gnome-tabbar-tab-color) !important;
-	background-color: var(--gnome-tabbar-tab-background) !important;
 }
 tab:hover {
 	color: var(--gnome-tabbar-tab-hover-color) !important;


### PR DESCRIPTION
Fixes #1138, however, now the tabs background colors cannot be changed from firefox/WhiteSur/colors/ css files to accomodate darker style.
