### PR TITLE
Correct --help prompt

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ usage() {
   helpify "--shell, --gnome-shell"        ""                                                  "  Tweaks for gnome-shell"                          "Options:"
   helpify "   1. -i, -icon"               "[$(IFS='|'; echo "${ICON_VARIANTS[*]}")]"          "    Set gnome-shell panel 'Activities' icon"       "Default is 'standard'"
   helpify "   2. -b, -background"         "[default|blank|IMAGE_PATH]"                        "    Set gnome-shell background image"              "Default is BigSur-like wallpaper"
-  helpify "   3. -o, -opacity"            "[$(IFS='|'; echo "${PANEL_OPACITY_VARIANTS[*]}")]" "    Set gnome-shell panel transparency"            "Default is 15%"
+  helpify "   3. -p, -panelopacity"       "[$(IFS='|'; echo "${PANEL_OPACITY_VARIANTS[*]}")]" "    Set gnome-shell panel transparency"            "Default is 15%"
   helpify "   4. -h, -height"             "[$(IFS='|'; echo "${PANEL_SIZE_VARIANTS[*]}")]"    "    Set gnome-shell panel height size"             "Default is 32px"
   helpify "   5. -n, -normal"            ""                                                  "    Set gnome-shell show apps button style to normal" "Default is BigSur"
   helpify "   6. -s, -smaller"           ""                                                  "    Set gnome-shell font size to smaller (10pt)"   "Default is 11pt"


### PR DESCRIPTION
Changed the panel opacity setting under --shell from -o to -p when running --help since -o no longer exists and is returned as unrecognized 



