### PR TITLE
fix: Theme parser error

### DIFF
--- a/src/sass/gtk/_common-4.0.scss
+++ b/src/sass/gtk/_common-4.0.scss
@@ -1516,7 +1516,7 @@ button.link {
   }
 
   &:hover {
-    color: HSL(from $link_color h calc(s * 1.1) calc(l * 1.1));
+    color: hsl(hue($link_color), saturation($link_color) * 1.1, lightness($link_color) * 1.1);
   }
 
   &:active {
@@ -3265,7 +3265,7 @@ $switch_animation: switch_ripple_effect 0.1s cubic-bezier(0, 0, 0.2, 1);
 
   to {
     background-image: $switch_checked_image, radial-gradient(circle farthest-corner at center,
-                                      RGB($selected_bg_color, 75%) 100%,
+                                      rgba($selected_bg_color, 0.75) 100%,
                                       transparent 0%);
   }
 }


### PR DESCRIPTION
This PR is to fix the theme parser error caused by GTK not understanding certain syntax.

```log
(org.gnome.Nautilus:4517): Gtk-WARNING **: 09:42:55.985: Theme parser error: gtk.css:1964:14-18: Expected a number

(org.gnome.Nautilus:4517): Gtk-WARNING **: 09:42:55.991: Theme parser error: gtk.css:3838:126-133: Expected a number

(org.gnome.Nautilus:4517): Gtk-WARNING **: 09:42:56.134: Theme parser error: gtk.css:1964:14-18: Expected a number

(org.gnome.Nautilus:4517): Gtk-WARNING **: 09:42:56.147: Theme parser error: gtk.css:3838:126-133: Expected a number
```