### PR TITLE
Fixed no gnome build issue

### DIFF
--- a/libs/lib-core.sh
+++ b/libs/lib-core.sh
@@ -47,6 +47,7 @@ if has_command gnome-shell; then
     GNOME_VERSION="3-28"
   fi
 else
+  SHELL_VERSION="48"
   GNOME_VERSION="48-0"
 fi
 


### PR DESCRIPTION
<!------------------------------------------------------------------------------
What's the changes?
------------------------------------------------------------------------------->

When gnome-shell isn't installed, `SHELL_VERSION`  stays empty.

Then in lib-install.sh:1099:

`sed $SED_OPT "/\GNOME_SHELL/s/46/$SHELL_VERSION/" "_shell-base-temp.scss"`

Sed wrties `$GNOME_SHELL:;` and breaks the compiler and build.
-
-
-

