### PR TITLE
Firefox radius visual bug fix

### DIFF
--- a/other/firefox/common/parts/csd.css
+++ b/other/firefox/common/parts/csd.css
@@ -6,8 +6,8 @@
 /* Headerbar top border corners rounded */
 &:root[sizemode="normal"]:not([gtktiledwindow="true"]) {
   #nav-bar {
-    border-top-left-radius: env(-moz-gtk-csd-titlebar-radius, 12px) !important;
-    border-top-right-radius: env(-moz-gtk-csd-titlebar-radius, 12px) !important;
+    border-top-left-radius: env(-moz-gtk-csd-titlebar-radius, 6px) !important;
+    border-top-right-radius: env(-moz-gtk-csd-titlebar-radius, 6px) !important;
     box-shadow: var(--gnome-headerbar-box-shadow) !important;
   }
 


### PR DESCRIPTION
Issue:
#1381 - Mismatched corner radius values cause visual bug.

Fix:
Reduced border radius for /* Headerbar top border corners rounded */ from 12px to 6px in csd.css file.

<!------------------------------------------------------------------------------
What's the changes?
------------------------------------------------------------------------------->

- Reduced border radius for /* Headerbar top border corners rounded */ from 12px to 6px in csd.css file.

