### PR TITLE
fix firefox issues

### DIFF
--- a/other/firefox/Monterey/parts/headerbar-urlbar.css
+++ b/other/firefox/Monterey/parts/headerbar-urlbar.css
@@ -205,11 +205,16 @@ toolbarspring {
 #notification-popup-box,
 #tracking-protection-icon-container,
 #trust-icon-container {
+	background-color: var(--gnome-urlbar-background) !important; 
 	width: 28px !important;
 	height: 26px !important;
 	margin: 3px 0 !important;
 	padding: 6px !important;
 	border-radius: 5px !important;
+}
+
+#trust-icon-container.insecure #trust-label {
+	display: none !important;
 }
 
 .urlbar-page-action {
@@ -230,6 +235,7 @@ toolbarspring {
 #urlbar-go-button:hover,
 .urlbar-go-button:hover,
 .search-go-button:hover,
+#trust-icon-container:hover,
 #identity-box:hover {
 	background: var(--gnome-headerbar-button-hover-background) !important;
 }
@@ -240,6 +246,7 @@ toolbarspring {
 #urlbar-go-button:active,
 .urlbar-go-button:active,
 .search-go-button:active,
+#trust-icon-container:active,
 #identity-box:active {
 	background: var(--gnome-headerbar-button-active-background) !important;
 }

--- a/other/firefox/WhiteSur/parts/headerbar-urlbar.css
+++ b/other/firefox/WhiteSur/parts/headerbar-urlbar.css
@@ -274,11 +274,16 @@ toolbarspring {
 #notification-popup-box,
 #tracking-protection-icon-container,
 #trust-icon-container {
+	background-color: var(--gnome-urlbar-background) !important; 
 	width: 28px !important;
 	height: 26px !important;
 	margin: 3px 0 !important;
 	padding: 6px !important;
 	border-radius: 5px !important;
+}
+
+#trust-icon-container.insecure #trust-label {
+	display: none !important;
 }
 
 .urlbar-page-action {
@@ -310,6 +315,7 @@ toolbarspring {
 #urlbar-go-button:hover,
 .urlbar-go-button:hover,
 .search-go-button:hover,
+#trust-icon-container:hover,
 #identity-box:hover {
 	background: var(--gnome-headerbar-button-hover-background) !important;
 }
@@ -320,6 +326,7 @@ toolbarspring {
 #urlbar-go-button:active,
 .urlbar-go-button:active,
 .search-go-button:active,
+#trust-icon-container:active,
 #identity-box:active {
 	background: var(--gnome-headerbar-button-active-background) !important;
 }

--- a/other/firefox/common/parts/popups.css
+++ b/other/firefox/common/parts/popups.css
@@ -135,6 +135,11 @@ panelview {
 	background: none !important;
 }
 
+.searchmode-switcher-panel-list {
+    --panel-list-background-color: transparent !important;
+    --panel-list-box-shadow: none !important;
+}
+
 panelview {
 	padding: var(--panel-padding) !important;
 }


### PR DESCRIPTION
fix(firefox): improve urlbar icon container styling and search mode panel appearance

- Add background-color variable for trust icon containers
- Hide trust-label for insecure connections
- Add hover/active styles for trust-icon-container to match other
  urlbar buttons
- Fix search mode switcher panel list background and box-shadow
  (set to transparent/none)

<!------------------------------------------------------------------------------
What's the changes?
------------------------------------------------------------------------------->
before：
<img width="193" height="43" alt="截图 2026-07-09 15-11-21" src="https://github.com/user-attachments/assets/6a399534-de97-4555-a2ac-837632f43ca7" />

<img width="242" height="558" alt="截图 2026-07-07 20-07-28" src="https://github.com/user-attachments/assets/ccddd8ac-fd3d-4d21-af97-112217faf676" />

after：
<img width="213" height="56" alt="截图 2026-07-11 22-05-14" src="https://github.com/user-attachments/assets/77b52664-bf59-46e1-87f1-abb4110efdf2" />

<img width="272" height="546" alt="截图 2026-07-07 20-13-31" src="https://github.com/user-attachments/assets/6ef36c79-8979-4a85-ba19-aeee4860548d" />

