### PR TITLE
fix(gnome-shell): prevent Astra Monitor hover tooltip text truncation

### DIFF
--- a/src/sass/gnome-shell/common/_popovers.scss
+++ b/src/sass/gnome-shell/common/_popovers.scss
@@ -99,6 +99,11 @@ $popop_menuitem_radius: $po_radius - $base_padding - if($variant=='light', 0, 2p
   border-width: if($variant=='light', 0, 1px);
 }
 
+.astra-monitor-tooltip-menu .popup-menu-content {
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
 .popup-menu-item {
   spacing: $base_spacing;
   padding: $base_padding * 1.5 $base_padding * 2;


### PR DESCRIPTION
Astra Monitor hover tooltips display truncated `...` instead of actual values (e.g., CPU usage `45%`) when using WhiteSur as the GNOME Shell user theme.

- Reset `.popup-menu-content` margin and padding for `.astra-monitor-tooltip-menu` to let the extension control its own sizing
- WhiteSur's default `margin: 4px 12px 17px 12px` and `padding: $base_padding` on `.popup-menu-content` compressed available space, causing GNOME Shell to ellipsize label text

before：tooltip shows `...` for all modules (CPU/GPU/Network/etc.)
after：tooltips display full values correctly