### PR TITLE
Gnome50 compat

### DIFF
--- a/src/sass/gtk/apps/_gnome-40.0.scss
+++ b/src/sass/gtk/apps/_gnome-40.0.scss
@@ -1599,6 +1599,38 @@ popover.details-popover {
   vte-terminal {
     background: none;
   }
+
+  toolbarview {
+    headerbar > windowhandle > box,
+    > .top-bar .collapse-spacing headerbar > windowhandle > box,
+    > .bottom-bar .collapse-spacing headerbar > windowhandle > box {
+      padding-block: 0;
+    }
+  }
+
+  headerbar {
+    splitbutton.horizontal.image-button > button.image-button {
+      border-top-right-radius: $bt_radius;
+      border-bottom-right-radius: $bt_radius;
+    }
+  }
+  
+  box.visual-bell-area {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
+
+//
+// Bazaar
+//
+
+.app-context-bar {
+  .lozenge,
+  .grey.lozenge {
+    background: none;
+    background-image: none;
+  }
 }
 
 //

--- a/src/sass/gtk/apps/_gnome-40.0.scss
+++ b/src/sass/gtk/apps/_gnome-40.0.scss
@@ -1604,11 +1604,18 @@ popover.details-popover {
     headerbar > windowhandle > box,
     > .top-bar .collapse-spacing headerbar > windowhandle > box,
     > .bottom-bar .collapse-spacing headerbar > windowhandle > box {
-      padding-block: 0;
+      padding-top: 0;
+      padding-bottom: 0;
     }
   }
 
   headerbar {
+    splitbutton.horizontal.image-button,
+    button.image-button.toggle {
+      margin-top: 8px;
+      margin-bottom: 8px;
+    }
+    
     splitbutton.horizontal.image-button > button.image-button {
       border-top-right-radius: $bt_radius;
       border-bottom-right-radius: $bt_radius;

--- a/src/sass/gtk/apps/_libadwaita.scss
+++ b/src/sass/gtk/apps/_libadwaita.scss
@@ -1093,3 +1093,26 @@ themeswitcher { // Gnome console
     }
   }
 }
+
+//
+// AdwTabOverview
+//
+
+tabthumbnail {
+  button.tab-close-button {
+    padding: 0;
+
+    &, &:hover, &:active, &:checked {
+      background: none;
+      border: none;
+      box-shadow: none;
+    }
+  }
+
+  .card,
+  picture {
+    border-radius: $wm_radius;
+    box-shadow: 0 1px 2px rgba(black, 0.02),
+                $wm_outline;
+  }
+}


### PR DESCRIPTION
fix: adapt themes for Ptyxis, Bazaar and AdwTabOverview
- Ptyxis: adjust headerbar height
- Bazaar: remove lozenge background
- AdwTabOverview: fix close button background

before:
<img width="1010" height="881" alt="截图 2026-07-23 00-13-28" src="https://github.com/user-attachments/assets/f8957748-902a-4cdb-b51c-3765375a6281" />
<img width="1787" height="610" alt="截图 2026-07-23 00-11-51" src="https://github.com/user-attachments/assets/1bdf49ef-0059-427a-b089-102a4e72d4fd" />
<img width="941" height="559" alt="截图 2026-07-23 00-12-08" src="https://github.com/user-attachments/assets/72494098-c08c-4a99-939f-6b9e78bf9ced" />

after:
<img width="1010" height="881" alt="截图 2026-07-22 23-54-37" src="https://github.com/user-attachments/assets/53b113c7-6ba4-439b-80ec-c73527669c4c" />
<img width="941" height="577" alt="截图 2026-07-23 00-05-10" src="https://github.com/user-attachments/assets/659ac235-82b6-4c2f-992e-d789164ddcb5" />
<img width="941" height="577" alt="截图 2026-07-23 00-05-16" src="https://github.com/user-attachments/assets/e1151459-cc6b-45a3-b8f4-b4c5847d70f7" />

